### PR TITLE
Use traditional `addListener()` and `removeListener()`

### DIFF
--- a/src/why/mqtt/client/MqttJsClient.hx
+++ b/src/why/mqtt/client/MqttJsClient.hx
@@ -52,8 +52,6 @@ class MqttJsClient extends BaseClient {
 					
 					native.once('connect', function onConnect(o) {
 						haxe.Timer.delay(resolve.bind({sessionPresent: o.sessionPresent}), 0);  // there may be error right after connect and we should prioritize that
-						native.off('connect', onConnect); // TODO: not sure we still need this
-						// native.off('error', onConnectFail); // TODO: not sure we still need this
 
 						native.on('message', function onMessage(topic, payload:Buffer, packet) messageReceivedTrigger.trigger(new Message(topic, payload, packet.qos, packet.retain)));
 						

--- a/src/why/mqtt/client/MqttJsClient.hx
+++ b/src/why/mqtt/client/MqttJsClient.hx
@@ -14,7 +14,7 @@ class MqttJsClient extends BaseClient {
 		super();
 		this.config = config;
 	}
-	
+
 	function doConnect():Promise<Connack> {
 		return if(native != null) {
 			new Error(Conflict, 'Already attempted to connect');
@@ -64,8 +64,8 @@ class MqttJsClient extends BaseClient {
 						});
 						native.on('message', function onMessage(topic, payload:Buffer, packet) messageReceivedTrigger.trigger(new Message(topic, payload, packet.qos, packet.retain)));
 						bindings = [
-							native.off.bind('close', onClose),
-							native.off.bind('message', onMessage)
+							native.removeListener.bind('close', onClose),
+							native.removeListener.bind('message', onMessage)
 						];
 					});
 					native.once('error', function onConnectFail(err) {
@@ -75,8 +75,8 @@ class MqttJsClient extends BaseClient {
 						}
 					});
 					initBindings = [
-						native.off.bind('connect', onConnect),
-						native.off.bind('error', onConnectFail),
+						native.removeListener.bind('connect', onConnect),
+						native.removeListener.bind('error', onConnectFail),
 					];
 				}
 				catch(e)
@@ -153,6 +153,7 @@ extern class Native {
 	function on(event:String, f:Function):Void;
 	function once(event:String, f:Function):Void;
 	function off(event:String, f:Function):Void;
+	function removeListener(event:String, f:Function):Void;
 	function publish(topic:String, payload:Buffer, options:{}, cb:(err:js.lib.Error)->Void):Void;
 	function subscribe(topic:String, options:{}, cb:(err:js.lib.Error, granted:Array<{topic:String, qos:Qos}>)->Void):Void;
 	function unsubscribe(topic:String, ?cb:(err:js.lib.Error)->Void):Void;

--- a/src/why/mqtt/client/MqttJsClient.hx
+++ b/src/why/mqtt/client/MqttJsClient.hx
@@ -56,13 +56,13 @@ class MqttJsClient extends BaseClient {
 						initBindings.cancel();
 						var bindings:CallbackLink = null;
 						
-						native.on('close', function onClose() {
+						native.addListener('close', function onClose() {
 							disconnectedTrigger.trigger(Noise);
 							if(!autoReconnect) {
 								bindings.cancel();
 							}
 						});
-						native.on('message', function onMessage(topic, payload:Buffer, packet) messageReceivedTrigger.trigger(new Message(topic, payload, packet.qos, packet.retain)));
+						native.addListener('message', function onMessage(topic, payload:Buffer, packet) messageReceivedTrigger.trigger(new Message(topic, payload, packet.qos, packet.retain)));
 						bindings = [
 							native.removeListener.bind('close', onClose),
 							native.removeListener.bind('message', onMessage)
@@ -150,9 +150,10 @@ typedef MqttJsClientConfig = Config & {
 #end
 extern class Native {
 	static function connect(url:String, options:{}):Native;
-	function on(event:String, f:Function):Void;
 	function once(event:String, f:Function):Void;
+	function on(event:String, f:Function):Void;
 	function off(event:String, f:Function):Void;
+	function addListener(event:String, f:Function):Void;
 	function removeListener(event:String, f:Function):Void;
 	function publish(topic:String, payload:Buffer, options:{}, cb:(err:js.lib.Error)->Void):Void;
 	function subscribe(topic:String, options:{}, cb:(err:js.lib.Error, granted:Array<{topic:String, qos:Qos}>)->Void):Void;

--- a/src/why/mqtt/client/MqttJsClient.hx
+++ b/src/why/mqtt/client/MqttJsClient.hx
@@ -152,7 +152,7 @@ extern class Native {
 	static function connect(url:String, options:{}):Native;
 	function once(event:String, f:Function):Void;
 	function on(event:String, f:Function):Void;
-	function off(event:String, f:Function):Void;
+	function off(event:String, f:Function):Void; // For latest mqtt version is missing this function, https://github.com/mqttjs/MQTT.js/issues/1552
 	function addListener(event:String, f:Function):Void;
 	function removeListener(event:String, f:Function):Void;
 	function publish(topic:String, payload:Buffer, options:{}, cb:(err:js.lib.Error)->Void):Void;


### PR DESCRIPTION
Currently mqtt version is missing `.off()`, https://github.com/mqttjs/MQTT.js/issues/1552. It's better not to use alias function.